### PR TITLE
Configure Claude review to trigger only on @claudereview mention

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,10 +38,7 @@ jobs:
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"
           
-          # Custom trigger phrase for code reviews
-          trigger_phrase: "@claudereview"
-          
-          # Direct prompt for when @claudereview is mentioned
+          # Direct prompt for when @claudereview is mentioned  
           direct_prompt: |
             Please review this pull request and provide feedback on:
             - Code quality and best practices

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,29 +1,27 @@
 name: Claude Code Review
 
 on:
-  pull_request:
-    types: [opened, synchronize]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claudereview')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claudereview')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claudereview'))
     
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
+      actions: read
     
     steps:
       - name: Checkout repository
@@ -40,7 +38,10 @@ jobs:
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"
           
-          # Direct prompt for automated review (no @claude mention needed)
+          # Custom trigger phrase for code reviews
+          trigger_phrase: "@claudereview"
+          
+          # Direct prompt for when @claudereview is mentioned
           direct_prompt: |
             Please review this pull request and provide feedback on:
             - Code quality and best practices
@@ -54,25 +55,6 @@ jobs:
           # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
           # use_sticky_comment: true
           
-          # Optional: Customize review based on file types
-          # direct_prompt: |
-          #   Review this PR focusing on:
-          #   - For TypeScript files: Type safety and proper interface usage
-          #   - For API endpoints: Security, input validation, and error handling
-          #   - For React components: Performance, accessibility, and best practices
-          #   - For tests: Coverage, edge cases, and test quality
-          
-          # Optional: Different prompts for different authors
-          # direct_prompt: |
-          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 
-          #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
-          #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
-          
           # Optional: Add specific tools for running tests or linting
-          # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
-          
-          # Optional: Skip review for certain conditions
-          # if: |
-          #   !contains(github.event.pull_request.title, '[skip-review]') &&
-          #   !contains(github.event.pull_request.title, '[WIP]')
+          # allowed_tools: "Bash(uv run python -m pytest),Bash(uv run python test_smoke.py)"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,13 +33,15 @@ A Streamlit dashboard allows the user to browse the database.
 
 This repository uses a PR-based development workflow:
 
-1. **Making Changes**: When requesting changes from Claude Code, work will be done on feature branches (prefixed with `claude-`)
-2. **Automatic PRs**: Claude Code will automatically create pull requests for changes
-3. **CI Testing**: GitHub Actions runs three test jobs on every PR:
+1. **Before Starting**: Always pull the latest main branch before starting new work
+2. **Making Changes**: When requesting changes from Claude Code, work will be done on feature branches (prefixed with `claude-`)
+3. **Automatic PRs**: Claude Code will automatically create pull requests for changes
+4. **CI Testing**: GitHub Actions runs three test jobs on every PR:
    - **Smoke Test**: Complete pipeline with 1 record (`BGGFINNA_TEST=2`)
    - **Unit Tests**: Existing pytest test suite
    - **Integration Test**: Full pipeline with limited data (`BGGFINNA_TEST=1`)
-4. **Review & Merge**: Review PRs in GitHub before merging to main branch
+5. **Code Review**: Comment `@claudereview` on PRs to trigger automated Claude code review
+6. **Review & Merge**: Review PRs in GitHub before merging to main branch
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- Configure Claude code review workflow to only run when `@claudereview` is mentioned in comments
- Keeps the structured direct_prompt for consistent review feedback
- Prevents automatic reviews on every PR, giving users control over when to request Claude reviews

## Changes
- **Workflow Triggers**: Changed from `pull_request` events to comment-based events (`issue_comment`, `pull_request_review_comment`, `pull_request_review`)
- **Trigger Condition**: Added condition to only run when `@claudereview` is mentioned in comment body
- **Permissions**: Updated to include `pull-requests: write` and `issues: write` for comment interactions
- **Direct Prompt**: Retained structured review prompt for consistent feedback on code quality, bugs, performance, security, and test coverage
- **Documentation**: Updated CLAUDE.md to explain the new `@claudereview` usage and added reminder to pull main before starting new branches

## Usage
Comment `@claudereview` on any PR to trigger an automated Claude code review with structured feedback.

🤖 Generated with [Claude Code](https://claude.ai/code)